### PR TITLE
Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant::Config.run do |config|
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "http://www.roe.ac.uk/~jsm/lofar_vm/LOFAR_precise64.box"
+  config.vm.box_url = "http://lofar.adrastea.es:8080/~jsm/LOFAR_VM.box"
 
   # Boot with a GUI so you can see the screen. (Default is headless)
   # config.vm.boot_mode = :gui


### PR DESCRIPTION
With this new file it is possible to use a vagrant box with the LOFAR software installed and all teh dependencies to develop losoto. The repository will be mounted in the box in **/home/vagrant/losoto**. The box can be started with `vagrant up`. Be aware that the size of the box is ~5.5 GB, it will take some time to download it and it will require about 12 GB of free space in the local computer. 
