### PR TITLE
Load information from files

### DIFF
--- a/tools/H5parm_importer.py
+++ b/tools/H5parm_importer.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# This tool is used to convert a parmdb into a H5parm format.
-# It can be run on a globaldb created with parmdb_collector.py
-# or on a single SB which contains the necessary
-# sky/instrument/ANTENNA/FIELD tables.
-# It handles Gain/DirectionalGain/RotationAngle/CommonRotationAngle/CommonScalarPhase solution types.
-
+"""
+This tool is used to convert a parmdb into a H5parm format.
+It can be run on a globaldb created with parmdb_collector.py
+or on a single SB which contains the necessary
+sky/instrument/ANTENNA/FIELD tables.
+It can also load a dictionary from a json or pickle file with the keys 
+instrumentdb (array with file names), antenna, field and skydb containing the 
+corresponding file names.
+It handles Gain/DirectionalGain/RotationAngle/
+           /CommonRotationAngle/CommonScalarPhase solution types.
+"""
 # Authors:
 # Francesco de Gasperin
 _author = "Francesco de Gasperin (fdg@hs.uni-hamburg.de)"
@@ -20,7 +24,8 @@ import pyrap.tables as pt
 import lofar.parmdb
 import losoto._version
 import losoto._logging
-from losoto.h5parm import h5parm, solWriter
+from losoto.h5parm import solWriter
+from losoto.h5parm import h5parm as h5parm2
 
 
 def parmdbToAxes(solEntry):
@@ -81,56 +86,27 @@ def parmdbToAxes(solEntry):
     return pol, dir, ant, parm
 
 
-if __name__=='__main__':
-    # Options
-    import optparse
-    opt = optparse.OptionParser(usage='%prog [-v] <H5parm> <globaldb/SBname> \n'\
-                    +_author, version='%prog '+losoto._version.__version__)
-    opt.add_option('-v', '--verbose', help='Go Vebose! (default=False)', action='store_true', default=False)
-    opt.add_option('-s', '--solset', help='Solution-set name (default=sol###)', type='string', default=None)
-    opt.add_option('-i', '--instrument', help='Name of the instrument table (default=instrument*)', type='string', default='instrument*')
-    opt.add_option('-c', '--complevel', help='Compression level from 0 (no compression, fast) to 9 (max compression, slow) (default=5)', type='int', default='5')
-    (options, args) = opt.parse_args()
-
-    # Check options
-    if len(args) != 2:
-        opt.print_help()
-        sys.exit()
-    if options.verbose: losoto._logging.setLevel("debug")
-
-    h5parmFile = args[0]
-    logging.info("H5parm filename = "+h5parmFile)
-
-    globaldbFile = args[1]
-    if not os.path.exists(globaldbFile):
-        logging.critical('Input globaldb/SB file not found.')
-        sys.exit(1)
-    logging.info("globaldb filename = "+globaldbFile)
-
-    complevel = options.complevel
-
-    # Check is all the necessary files are available
-    antennaFile = os.path.join(globaldbFile,'ANTENNA')
-    if not os.path.isdir(antennaFile):
-        logging.critical('Missing ANTENNA table.')
-        sys.exit(1)
-    fieldFile = os.path.join(globaldbFile,'FIELD')
-    if not os.path.isdir(fieldFile):
-        logging.critical('Missing FIELD table.')
-        sys.exit(1)
-    skydbFile = os.path.join(globaldbFile,'sky')
-
-    # Make a list of all available instrument tables (only 1 for a standard MS)
-    instrumentdbFiles = [ instrumentdbFile for instrumentdbFile in \
-        glob.glob(os.path.join(globaldbFile,options.instrument)) \
-        if os.path.isdir(instrumentdbFile) ]
-
+def create_h5parm(instrumentdbFiles, antennaFile, fieldFile, skydbFile,
+                  h5parmFile, complevel, solsetName, globaldbFile=None):
+    """
+    Create the h5parm file.
+    Input:
+       instrumentdbFiles - list of the finenames of the solutions.
+       antennaFile - file name of the antenna table.
+       fieldFile - file name of the field table.
+       skydbFile - file name of the sky table.
+       h5parmFile - file name of the h5parm file that will be created.
+       complevel - level of compression. It is usually 5.
+       solsetName - Name of the solution set. Usually "sol###".
+       globaldbFile (optional) - Name of the globaldbFile. Used only for 
+         logging purposes.
+    """
+    
     # open/create the h5parm file and the solution-set
-    h5parm = h5parm(h5parmFile, readonly = False, complevel = complevel)
-
-    solsetName = options.solset
+    h5parm = h5parm2(h5parmFile, readonly = False, complevel = complevel)
+    
     solset = h5parm.makeSolset(solsetName)
-
+    
     # Create tables using the first instrumentdb
     # TODO: all the instrument tables should be checked
     pdb = lofar.parmdb.parmdb(instrumentdbFiles[0])
@@ -386,9 +362,98 @@ if __name__=='__main__':
     soltabs = h5parm.getSoltabs(solset=solset)
     for st in soltabs:
         sw = solWriter(soltabs[st])
-        sw.addHistory('CREATE (by H5parm_importer.py from %s:%s/%s)' % (socket.gethostname(), os.path.abspath(''), globaldbFile))
+        if globaldbFile is None:
+            sw.addHistory('CREATE (by H5parm_importer.py from %s:%s/%s)' % (socket.gethostname(), os.path.abspath(''), "manual list"))
+        else:
+            sw.addHistory('CREATE (by H5parm_importer.py from %s:%s/%s)' % (socket.gethostname(), os.path.abspath(''), globaldbFile))
     if options.verbose:
         logging.info(str(h5parm))
 
     del h5parm
-    logging.info('Done.')
+    logging.info('Done.')    
+    
+
+if __name__=='__main__':
+    # Options
+    import optparse
+    opt = optparse.OptionParser(usage='%prog [-v] <H5parm> <globaldb/SBname> \n'\
+                    +_author, version='%prog '+losoto._version.__version__)
+    opt.add_option('-v', '--verbose', help='Go Vebose! (default=False)', action='store_true', default=False)
+    opt.add_option('-s', '--solset', help='Solution-set name (default=sol###)', type='string', default=None)
+    opt.add_option('-i', '--instrument', help='Name of the instrument table (default=instrument*)', type='string', default='instrument*')
+    opt.add_option('-c', '--complevel', help='Compression level from 0 (no compression, fast) to 9 (max compression, slow) (default=5)', type='int', default='5')
+    (options, args) = opt.parse_args()
+
+    # Check options
+    if len(args) != 2:
+        opt.print_help()
+        sys.exit()
+    if options.verbose: losoto._logging.setLevel("debug")
+
+    h5parmFile = args[0]
+    logging.info("H5parm filename = "+h5parmFile)
+    
+    # Common options
+    complevel = options.complevel
+    solsetName = options.solset
+
+    input_file = args[1]
+    
+    if input_file.endswith(".json"):
+        try:
+            import json
+            logging.info("Loading json file: {}".format(input_file))
+            files = json.load(open(input_file,"r"))
+            instrumentdbFiles = [str(f) for f in files["instrumentdb"]]
+            antennaFile = str(files["antenna"])
+            fieldFile = str(files["field"])
+            skydbFile = str(files["skydb"])
+            globaldbFile = None
+        except:
+            logging.critical('Loading failed')
+    elif input_file.endswith(".pckl"):
+        try:
+            import pickle
+            logging.info("Loading pickle file: {}".format(input_file))
+            files = pickle.load(open(input_file,"r"))
+            instrumentdbFiles = files["instrumentdb"]
+            antennaFile = files["antenna"]
+            fieldFile = files["field"]
+            skydbFile = files["skydb"]
+            globaldbFile = None
+        except:
+            logging.critical('Loading failed')
+    else:
+        globaldbFile = input_file
+        if not os.path.exists(globaldbFile):
+            logging.critical('Input globaldb/SB file not found.')
+            sys.exit(1)
+        logging.info("globaldb filename = "+globaldbFile)
+        
+        # Load the path of the files
+        antennaFile = os.path.join(globaldbFile,'ANTENNA')
+        fieldFile = os.path.join(globaldbFile,'FIELD')
+        skydbFile = os.path.join(globaldbFile,'sky')
+
+        # Make a list of all available instrument tables (only 1 for a standard MS)
+        instrumentdbFiles = [ instrumentdbFile for instrumentdbFile in \
+            glob.glob(os.path.join(globaldbFile,options.instrument)) \
+            if os.path.isdir(instrumentdbFile) ]
+
+    # Check antennaFile and fieldFile
+    if not os.path.isdir(antennaFile):
+        logging.critical('Missing ANTENNA table.')
+        sys.exit(1)
+    if not os.path.isdir(fieldFile):
+        logging.critical('Missing FIELD table.')
+        sys.exit(1)
+            
+    
+    # Call the method that creates the h5parm file
+    create_h5parm(instrumentdbFiles, antennaFile, fieldFile, skydbFile,
+                  h5parmFile, complevel, solsetName, globaldbFile=globaldbFile)
+
+
+    
+    
+


### PR DESCRIPTION
I modified H5parm_importer.py to be able to load the names of the input filed from configuration files. It should work with the global db as usual but also accept now a json of a pckl file containing a dictionary with the names of the files.
The creation of the H5parm is separated in a function that gets the file names. The parsing of the options is practically the same but, if the globaldb name ends with "json" or "pckl" it will load the info from these type of files.
In general this allows to generalize a bit the load of the information. It has proven to be very useful in "non-standard" systems like mine.
Please, check that it still works with globaldb files as intended (It should but...).