### PR TITLE
Fixes H5parm_exporter.py for numpy 1.12.0

### DIFF
--- a/bin/H5parm_exporter.py
+++ b/bin/H5parm_exporter.py
@@ -548,9 +548,9 @@ if __name__=='__main__':
                         nfreq = freqs.shape[0]
                         #print val.shape
                         # reshape such that all freq arrays are filled properly
-                        val = np.tile( val, np.append([nfreq], np.ones(len(val.shape)) ) )
+                        val = np.tile( val, np.append([nfreq], np.ones(len(val.shape),dtype=np.int) ) )
                         #print val.shape
-                        weights = np.tile( weights, np.append([nfreq], np.ones(len(weights.shape)) ) )
+                        weights = np.tile( weights, np.append([nfreq], np.ones(len(weights.shape),dtype=np.int) ) )
 
                     flags = np.zeros(shape=weights.shape, dtype=bool)
                     flags[np.where(weights == 0)] = True


### PR DESCRIPTION
Very minor change to make sure reps argument for numpy.tile are integers rather than floats.
Fixes issue #17 and makes the script compatible for numpy >= 1.12.0.
Tested on 1.12.0 and 1.11.0 and is fine for numpy v1.9.0.

Note that other uses of np.tile may crash with >=1.12.0 versions of numpy (e.g. in losoto/operations/fitClockTEC.py) if the second argument is not, or contains, integers.