### PR TITLE
Skip plotting of all flagged data

### DIFF
--- a/losoto/operations/plot.py
+++ b/losoto/operations/plot.py
@@ -6,6 +6,7 @@
 
 import logging
 from losoto.operations_lib import *
+import numpy.ma
 
 logging.debug('Loading PLOT module.')
 
@@ -76,7 +77,10 @@ def plot(Nplots, NColFig, figSize, cmesh, axesInPlot, axisInTable, xvals, yvals,
                 else:
                     color = plt.cm.jet(Ncol/float(len(dataCube[Ntab])-1)) # from 0 to 1
                     colorFlag = 'k'
+
                 vals = dataCube[Ntab][Ncol]
+                if numpy.ma.getmask(dataCube[Ntab][Ncol]).all()
+                    continue
 
                 # plotting
                 if cmesh:


### PR DESCRIPTION
Losoto hangs because it tries to plot all flagged data (on matplotlib 2.1.0, the one on CEP3). A thread throws the following error, after which losoto hangs.
```
AttributeError: 'MaskedConstant' object has no attribute '_fill_value'
```

Probably the same error as our SA friends ran into in ratt-ru/CubiCal/issues/72 .