### PR TITLE
Some changes for python3

### DIFF
--- a/bin/H5parm_exporter.py
+++ b/bin/H5parm_exporter.py
@@ -409,7 +409,7 @@ if __name__=='__main__':
             if s.name in soltabs_to_use:
                 solTabs_filt.append(s)
         for s in soltabs_to_use:
-            if s.name not in solset.getSoltabNames()):
+            if s.name not in solset.getSoltabNames():
                 logging.warning('Solution table {0} not found in input H5parm file.'.format(s.name))
         solTabs = solTabs_filt
     if len(solTabs) == 0:

--- a/losoto/h5parm.py
+++ b/losoto/h5parm.py
@@ -667,7 +667,11 @@ class Soltab( object ):
         self.name = soltab._v_name
 
         # list of axes names, set once to speed up calls
-        self.axesNames = soltab.val.attrs['AXES'].split(',')
+        axesNamesInH5 = soltab.val.attrs['AXES']
+        if not isinstance(axesNamesInH5, str):
+            # This is necessary in python3
+            axesNamesInH5 = str(soltab.val.attrs['AXES'], 'utf-8')
+        self.axesNames = axesNamesInH5.split(',')
 
         # dict of axes values, set once to speed up calls (a bit of memory usage though)
         self.axes = {}

--- a/losoto/lib_unwrap.py
+++ b/losoto/lib_unwrap.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #from __future__ import division
+from __future__ import print_function
 import numpy as np
 import scipy.fftpack as fft
 import logging
@@ -227,9 +228,9 @@ if __name__ == "__main__":
     #    phase_unwrapped = unwrap_dct(phase_wrapped)
     t1 = time()-t0
     coord = None
-    print( 'time:\t%fs'%(t1))
+    print('time:\t%fs'%(t1))
     
-    print( 'norm:', np.abs(phase_unwrapped-phase_orig) )
+    print('norm:', np.abs(phase_unwrapped-phase_orig) )
     
     fig, ((ax1,ax2),(ax3,ax4)) = pl.subplots(2,2)
     im1 = ax1.imshow(phase_orig.__array__())

--- a/losoto/operations/example.py
+++ b/losoto/operations/example.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This is an example operation for LoSoTo
+from __future__ import print_function
 
 import logging
 from losoto.lib_operations import *
@@ -77,8 +78,8 @@ def run( soltab, opt1, opt2 = [1., 2., 3.], opt3 = 0 ):
     # axis names
     logging.info("Axes: "+str(soltab.getAxesNames()))
     # axis shape
-    print axes
-    print [soltab.getAxisLen(axis) for axis in axes] # not ordered, is a dict!
+    print(axes)
+    print([soltab.getAxisLen(axis) for axis in axes]) # not ordered, is a dict!
     # data array shape (same of axis shape)
     logging.info("Shape of values: "+str(grid.shape))
     #logging.info("$ val is "+str(grid[0,0,0,0,100]))

--- a/losoto/operations/faraday.py
+++ b/losoto/operations/faraday.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import logging
 from losoto.lib_operations import *
@@ -137,7 +138,7 @@ def run( soltab, refAnt='', maxResidual=1. ):
                     # Debug plot
                     doplot = False
                     if doplot and coord['ant'] == 'RS310LBA' and t%10==0:
-                        print "Plotting"
+                        print("Plotting")
                         if not 'matplotlib' in sys.modules:
                             import matplotlib as mpl
                             mpl.rc('font',size =8 )

--- a/losoto/operations/plot.py
+++ b/losoto/operations/plot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import logging
 from losoto.lib_operations import *
@@ -536,7 +537,7 @@ def run(soltab, axesInPlot, axisInTable='', axisInCol='', axisDiff='', NColFig=0
         ss="mencoder -ovc lavc -lavcopts vcodec=mpeg4:vpass=1:vbitrate=6160000:mbd=2:keyint=132:v4mv:vqmin=3:lumi_mask=0.07:dark_mask=0.2:"+\
                 "mpeg_quant:scplx_mask=0.1:tcplx_mask=0.1:naq -mf type=png:fps="+str(fps)+" -nosound -o "+movieName.replace('__tmp__','')+".mpg mf://"+movieName+"*  > mencoder.log 2>&1"
         os.system(ss)
-        print ss
+        print(ss)
         #for png in pngs: os.system('rm '+png)
 
     return 0

--- a/losoto/operations/prefactor_XYoffset.py
+++ b/losoto/operations/prefactor_XYoffset.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import logging
 from losoto.lib_operations import *
@@ -50,8 +51,8 @@ def run( soltab):
     nsubbands = len(subbands)
     nchan = len(freqs)/nsubbands
     if nsubbands*nchan != len(freqs):
-        print "find_cal_global_phaseoffset_losoto.py: irregular number of ch/SB detected! Bailing out!"
-        print "  nchan %d, nSB: %d, nfreq: %d" % (nchan, nsubbands, len(freqs))
+        print("find_cal_global_phaseoffset_losoto.py: irregular number of ch/SB detected! Bailing out!")
+        print("  nchan %d, nSB: %d, nfreq: %d" % (nchan, nsubbands, len(freqs)))
         sys.exit(1)
     tmpfreqs = freqs.reshape([nsubbands,nchan])
     freq_per_sb = np.mean(tmpfreqs,axis=1)

--- a/losoto/operations/tec.py
+++ b/losoto/operations/tec.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import logging
 from losoto.lib_operations import *
@@ -155,7 +156,7 @@ def run( soltab, soltabOut='tec000', refAnt='', maxResidual=1. ):
                     # Debug plot
                     doplot = True
                     if doplot and (coord['ant'] == 'RS509LBA' or coord['ant'] == 'RS210LBA') and t%50==0:
-                        print "Plotting"
+                        print("Plotting")
                         if not 'matplotlib' in sys.modules:
                             import matplotlib as mpl
                             mpl.rc('figure.subplot',left=0.05, bottom=0.05, right=0.95, top=0.95,wspace=0.22, hspace=0.22 )


### PR DESCRIPTION
Here are a couple of minor fixes which makes the h5parm bit work on python3. Not sure if all losoto works; there are no tests...

The biggest change is how strings are handled. In python3, tables returns arrays of bytes rather than strings. I changed this to strings.

The changes should be backward compatible with python 2.