### PR TITLE
Python3

### DIFF
--- a/losoto/h5parm.py
+++ b/losoto/h5parm.py
@@ -936,10 +936,16 @@ class Soltab( object ):
             return None
 
         if ignoreSelection:
-            return np.copy(self.axes[axis])
+            axisvalues = np.copy(self.axes[axis])
         else:
             axisIdx = self.getAxesNames().index(axis)
-            return np.copy(self.axes[axis][ self.selection[axisIdx] ])
+            axisvalues = np.copy(self.axes[axis][ self.selection[axisIdx] ])
+
+        if axisvalues.dtype.str[0:2] == '|S':
+            # Convert to native string format for python 3
+            return axisvalues.astype(str)
+        else:
+            return axisvalues
 
 
     def setAxisValues(self, axis, vals):

--- a/losoto/operations/__init__.py
+++ b/losoto/operations/__init__.py
@@ -25,8 +25,8 @@ class timer(object):
         self.start = time.time()
         self.startcpu = time.clock()
 
-    def __exit__(self, type, value, tb):
+    def __exit__(self, exit_type, value, tb):
 
-        if type is not None:
-            raise type, value, tb
+        if exit_type is not None:
+            raise RuntimeError("timer.__init__ should not be called with ({}, {}, {})".format(exit_type, value, tb))
         self.log.info("Time for this step: %i s (cpu: %i s)." % ( ( time.time() - self.start), (time.clock() - self.startcpu) ))


### PR DESCRIPTION
The reserved word `type` should probably not be used as a variable.
Raising tuples is not allowed in python3, raise a RuntimeError instead.
In python3, the values of a string axis were returned as bytes; convert them to native strings instead (in python3 that's unicode).