### PR TITLE
remove the selection checking against range for 2.7 compatibility

### DIFF
--- a/losoto/h5parm.py
+++ b/losoto/h5parm.py
@@ -787,7 +787,7 @@ class Soltab( object ):
             idx = self.getAxesNames().index(axis)
             
             # slice -> let the slice be as it is
-            if isinstance(selVal, (slice, range)):
+            if isinstance(selVal, slice):
                 self.selection[idx] = selVal
             # string -> regular expression
             elif type(selVal) is str:


### PR DESCRIPTION
in python 2.7 range is not a class, so only allow instance checking against slice for posterity