### PR TITLE
Add a flag to export just XX,YY from killMS solutions.

### DIFF
--- a/bin/killMS2H5parm.py
+++ b/bin/killMS2H5parm.py
@@ -22,6 +22,7 @@ if __name__=='__main__':
     opt.add_option('-V', '--verbose', help='Go Vebose! (default=False)', action='store_true', default=False)
     opt.add_option('-s', '--solset', help='Solution-set name (default=sol###)', type='string', default=None)
     opt.add_option('-c', '--complevel', help='Compression level from 0 (no compression, fast) to 9 (max compression, slow) (default=5)', type='int', default='5')
+    opt.add_option('--nofulljones', help='Export the solutions as just XX/YY instead of XX,XY,YX,YY.', action='store_false', dest='fulljones', default=True)
     (options, args) = opt.parse_args()
 
     # Check options
@@ -60,7 +61,6 @@ if __name__=='__main__':
 
     #print SolsDico.keys()
     #print Sols.dtype.names
-    pols = ['XX','XY','YX','YY']
     times = (Sols["t0"]+Sols["t1"])/2.
     freqs = (SolsDico['FreqDomains'][:,0]+SolsDico['FreqDomains'][:,1])/2.
 
@@ -72,17 +72,29 @@ if __name__=='__main__':
     
     
     # construct solution arrays
-    tt, tf, ta, td, _, _ = Sols['G'].shape
-    vals_amp = np.zeros(shape=(tt,tf,ta,td,4))
-    vals_ph = np.zeros(shape=(tt,tf,ta,td,4))
-    vals_amp[...,0] = np.abs(Sols['G'][...,0,0])
-    vals_amp[...,1] = np.abs(Sols['G'][...,0,1])
-    vals_amp[...,2] = np.abs(Sols['G'][...,1,0])
-    vals_amp[...,3] = np.abs(Sols['G'][...,1,1])
-    vals_ph[...,0] = np.angle(Sols['G'][...,0,0])
-    vals_ph[...,1] = np.angle(Sols['G'][...,0,1])
-    vals_ph[...,2] = np.angle(Sols['G'][...,1,0])
-    vals_ph[...,3] = np.angle(Sols['G'][...,1,1])
+    if options.fulljones:
+        pols = ['XX','XY','YX','YY']
+        tt, tf, ta, td, _, _ = Sols['G'].shape
+        vals_amp = np.zeros(shape=(tt,tf,ta,td,4))
+        vals_ph = np.zeros(shape=(tt,tf,ta,td,4))
+        vals_amp[...,0] = np.abs(Sols['G'][...,0,0])
+        vals_amp[...,1] = np.abs(Sols['G'][...,0,1])
+        vals_amp[...,2] = np.abs(Sols['G'][...,1,0])
+        vals_amp[...,3] = np.abs(Sols['G'][...,1,1])
+        vals_ph[...,0] = np.angle(Sols['G'][...,0,0])
+        vals_ph[...,1] = np.angle(Sols['G'][...,0,1])
+        vals_ph[...,2] = np.angle(Sols['G'][...,1,0])
+        vals_ph[...,3] = np.angle(Sols['G'][...,1,1])
+    elif not options.fulljones:
+        pols = ['XX','YY']
+        tt, tf, ta, td, _, _ = Sols['G'].shape
+        vals_amp = np.zeros(shape=(tt,tf,ta,td,2))
+        vals_ph = np.zeros(shape=(tt,tf,ta,td,2))
+        vals_amp[...,0] = np.abs(Sols['G'][...,0,0])
+        vals_amp[...,1] = np.abs(Sols['G'][...,1,1])
+        vals_ph[...,0] = np.angle(Sols['G'][...,0,0])
+        vals_ph[...,1] = np.angle(Sols['G'][...,1,1])
+        
     #print vals_amp.shape
     #print len(pols), len(dirNames), len(antNames), len(freqs), len(times)
 


### PR DESCRIPTION
This adds an option to export just the XX and YY correlations, so they can be applied normally, i.e. not as `fulljones`, which gives me a bit of trouble at the moment when adding placeholder 1 (amp) or 0 (phase) solutions for the international staions.

It still exports fulljones by default, so this won't affect current functionality.