### PR TITLE
Import submodules with import *

### DIFF
--- a/losoto/operations/__init__.py
+++ b/losoto/operations/__init__.py
@@ -2,8 +2,7 @@ import os, time, glob
 
 __all__ = [ os.path.basename(f)[:-3] for f in glob.glob(os.path.dirname(__file__)+"/*.py") if f[0] != '_']
 
-for x in __all__:
-    __import__(x, locals(), globals())
+from . import *
 
 class Timer(object):
     """


### PR DESCRIPTION
The importing of all submodules leads to an error in python3 (maybe not all python3):
```
> python -c 'from losoto.operations import plot'
Python 3.6.8 |Anaconda, Inc.| (default, Dec 29 2018, 19:04:46)
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/dijkema/opt/losoto/losoto/operations/__init__.py", line 6, in <module>
    __import__(x, locals(), globals())
ModuleNotFoundError: No module named 'directionscreen'
```

I think the intention of the lines leading to the error is to import all python files in the directory, which can also be done by `from . import *`. I tested in python 2.7 and python 3.6 using
```
python -c 'from losoto.operations import plot'
```