### PR TITLE
Fix requirements

### DIFF
--- a/losoto/_version.py
+++ b/losoto/_version.py
@@ -4,7 +4,7 @@ This module simply stores the version
 """
 
 # Version number
-__version__ = '2.2'
+__version__ = '2.2.1'
 
 # H5parm version
 __h5parmVersion__ = '1.0'

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     ],
     tests_require=['pytest'],
     install_requires=['numpy>=1.9', 'cython', 'numexpr>=2.0', 'tables>=3.4', 'configparser',
-                      'scipy>=1.0,<1.6', 'matplotlib>=3.0,<3.4', 'python-casacore>=3.0', 'progressbar'],
+                      'scipy', 'matplotlib', 'python-casacore>=3.0', 'progressbar'],
     scripts=['bin/losoto', 'bin/H5parm_split.py',
              'bin/H5parm2parmdb.py', 'bin/parmdb2H5parm.py', 'bin/killMS2H5parm.py',
              'bin/H5parm_collector.py', 'bin/H5parm_copy.py', 'bin/H5parm_interpolator.py'],


### PR DESCRIPTION
Loosened the version requirements on `scipy` and `matplotlib`, which were too stringent. Bumped version number to `2.2.1`.