### PR TITLE
Implemented FRjump

### DIFF
--- a/bin/losoto
+++ b/bin/losoto
@@ -110,7 +110,7 @@ if __name__=='__main__':
                    "FLAG": operations.flag,
                    "FLAGEXTEND": operations.flagextend,
                    "FLAGSTATION": operations.flagstation,
-                   "FRJUMP": operation.frjump,
+                   "FRJUMP": operations.frjump,
                    "GLOBALDELAY": operations.globaldelay,
                    "INTERPOLATE": operations.interpolate,
                    "INTERPOLATEDIRECTIONS": operations.interpolatedirections,

--- a/losoto/operations/frjump.py
+++ b/losoto/operations/frjump.py
@@ -7,14 +7,15 @@ from losoto.operations._faraday_timestep import _run_timestep
 import astropy.constants as c
 
 logging.debug('Loading FRjump module.')
+logging.warning('FRjump module is still experimental - we strongly recommend to check the results carefully')
 
 
 def _run_parser(soltab, parser, step):
     soltabOut = parser.getstr( step, 'soltabOut', 'rotationmeasure002' )
     soltabPhase = parser.getstr( step, 'soltabPhase', 'phase000')
-    clipping = parser.getarray(step, 'clipping', [0,1e9])
+    clipping = np.array(parser.getarray(step, 'clipping', [0,1e9]),dtype=float)
 
-    parser.checkSpelling( step, soltab, ['soltabOut'])
+    parser.checkSpelling( step, soltab, ['soltabOut','soltabPhase','clipping'])
     return run(soltab, soltabOut,clipping, soltabPhase)
 
 def costfunctionRM(RM, wav, phase):
@@ -77,7 +78,7 @@ def run( soltab, soltabOut,clipping,soltabPhase):
     import numpy as np
     import scipy.optimize
 
-    c = 2.99792458e8
+    # c = 2.99792458e8
 
     vals = soltab.getValues(retAxesVals=False)
     ants = soltab.getAxisValues('ant')
@@ -88,7 +89,7 @@ def run( soltab, soltabOut,clipping,soltabPhase):
     selection = (freqs > clipping[0]) * (freqs < clipping[1]) # Only take the frequencies used for fitting
     selected_freqs = freqs[selection]
 
-    wavels = c/selected_freqs # in meters
+    wavels = (c.c/selected_freqs).value # in meters
 
     if soltabOut not in solset.getSoltabNames():
         soltabout = solset.makeSoltab('rotationmeasure',soltabName=soltabOut, 

--- a/losoto/operations/frjump.py
+++ b/losoto/operations/frjump.py
@@ -59,21 +59,23 @@ def dejump(vals,wavels):
 
 def run( soltab, soltabOut,clipping,soltabPhase):
     """
-    Faraday rotation extraction from either a rotation table or a circular phase (of which the operation get the polarisation difference).
+    'Dejumps' the Faraday solutions. Because Faraday rotation is a rotation, there are generally multiple possible values for the rotation measure
+    that yield a similar rotation angle - but are offset from the main trend. This code will fix this.
 
     Parameters
     ----------
     
     soltabOut : str, optional
-        output table name (same solset), by deault "rotationmeasure000".
+        output table name (same solset), by deault "rotationmeasure001".
         
-    refAnt : str, optional
-        Reference antenna, by default the first.
+    clipping : arr, optional
+        Refers to the frequency range that is used in the Faraday step. This is important to get a good estimate for the difference in RM
 
-    maxResidual : float, optional
-        Max average residual in radians before flagging datapoint, by default 1. If 0: no check.
-
+    soltabPhase : str, optional
+        name of soltab that contains the phases. The only reason we need this, is for the frequency axis (so it really doesnt matter what's in 
+        this soltab. Default: phase000
     """
+
     import numpy as np
     import scipy.optimize
 

--- a/losoto/operations/frjump.py
+++ b/losoto/operations/frjump.py
@@ -4,7 +4,6 @@
 from losoto.lib_operations import *
 from losoto._logging import logger as logging
 from losoto.operations._faraday_timestep import _run_timestep
-import astropy.constants as c
 
 logging.debug('Loading FRjump module.')
 logging.warning('FRjump module is still experimental - we strongly recommend to check the results carefully')
@@ -78,7 +77,7 @@ def run( soltab, soltabOut,clipping,soltabPhase):
     import numpy as np
     import scipy.optimize
 
-    # c = 2.99792458e8
+    c = 2.99792458e8
 
     vals = soltab.getValues(retAxesVals=False)
     ants = soltab.getAxisValues('ant')
@@ -89,7 +88,7 @@ def run( soltab, soltabOut,clipping,soltabPhase):
     selection = (freqs > clipping[0]) * (freqs < clipping[1]) # Only take the frequencies used for fitting
     selected_freqs = freqs[selection]
 
-    wavels = (c.c/selected_freqs).value # in meters
+    wavels = c/selected_freqs # in meters
 
     if soltabOut not in solset.getSoltabNames():
         soltabout = solset.makeSoltab('rotationmeasure',soltabName=soltabOut, 
@@ -106,7 +105,7 @@ def run( soltab, soltabOut,clipping,soltabPhase):
     for vals,weights,coord,_ in soltab.getValuesIter(returnAxes='time',weight=True):
         antname = coord['ant']
         newvals = dejump(vals,wavels)
-        logging.info(f'Doing antenna {antname}')
+        logging.debug(f'Doing antenna {antname}')
         soltabout.setSelection(ant=coord['ant'],time=coord['time'])          
         soltabout.setValues(np.expand_dims(newvals,axis=1))
     

--- a/losoto/operations/frjump.py
+++ b/losoto/operations/frjump.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from losoto.lib_operations import *
+from losoto._logging import logger as logging
+from losoto.operations._faraday_timestep import _run_timestep
+import astropy.constants as c
+
+logging.debug('Loading FRjump module.')
+
+
+def _run_parser(soltab, parser, step):
+    soltabOut = parser.getstr( step, 'soltabOut', 'rotationmeasure002' )
+    soltabPhase = parser.getstr( step, 'soltabPhase', 'phase000')
+    clipping = parser.getarray(step, 'clipping', [0,1e9])
+
+    parser.checkSpelling( step, soltab, ['soltabOut'])
+    return run(soltab, soltabOut,clipping, soltabPhase)
+
+def costfunctionRM(RM, wav, phase):
+    return np.sum(abs(np.cos(2.*RM[0]*wav*wav) - np.cos(phase)) + abs(np.sin(2.*RM[0]*wav*wav) - np.sin(phase)))
+
+def getPhaseWrapBase(wavels):
+    """
+    freqs: frequency grid of the data
+    return the step size from a local minima (2pi phase wrap) to the others [0]: TEC, [1]: clock
+    """
+    wavels = np.array(wavels)
+    nF = wavels.shape[0]
+    A = np.zeros((nF, 1), dtype=np.float)
+    A[:, 0] = 2*wavels**2
+    steps = np.dot(np.dot(np.linalg.inv(np.dot(A.T, A)), A.T), 2 * np.pi * np.ones((nF, ), dtype=np.float))
+    return steps
+
+def dejump(vals,wavels):
+    phasewrap = getPhaseWrapBase(wavels)
+    diffs = np.diff(vals)
+    
+    # Fix the jumps in diff-space
+    for i in range(len(diffs)):
+        while np.abs(diffs[i]) > phasewrap/2.:
+            if diffs[i] > phasewrap/2.:
+                diffs[i] -= phasewrap
+            elif diffs[i] < -phasewrap/2.:
+                diffs[i] += phasewrap
+                
+    newvals = np.zeros_like(vals)
+    newvals[0] = vals[0]
+    for i in range(len(diffs)):
+        newvals[i+1] = newvals[i] + diffs[i] # Here, we go back to normal-space
+    
+    delt_median = lambda nv: np.median(nv) - np.median(vals) # make sure that the median is within 1 phasejump
+    while np.abs(delt_median(newvals)) > phasewrap/2.:
+        if delt_median(newvals) > phasewrap/2.:
+            newvals -= phasewrap
+        elif delt_median(newvals) < -phasewrap/2.:
+            newvals += phasewrap
+    return newvals
+
+def run( soltab, soltabOut,clipping,soltabPhase):
+    """
+    Faraday rotation extraction from either a rotation table or a circular phase (of which the operation get the polarisation difference).
+
+    Parameters
+    ----------
+    
+    soltabOut : str, optional
+        output table name (same solset), by deault "rotationmeasure000".
+        
+    refAnt : str, optional
+        Reference antenna, by default the first.
+
+    maxResidual : float, optional
+        Max average residual in radians before flagging datapoint, by default 1. If 0: no check.
+
+    """
+    import numpy as np
+    import scipy.optimize
+
+    c = 2.99792458e8
+
+    vals = soltab.getValues(retAxesVals=False)
+    ants = soltab.getAxisValues('ant')
+    times = soltab.getAxisValues('time')
+    solset = soltab.getSolset()
+    phases = solset.getSoltab(soltabPhase)
+    freqs = phases.getValues()[1]['freq']
+    selection = (freqs > clipping[0]) * (freqs < clipping[1]) # Only take the frequencies used for fitting
+    selected_freqs = freqs[selection]
+
+    wavels = c/selected_freqs # in meters
+
+    if soltabOut not in solset.getSoltabNames():
+        soltabout = solset.makeSoltab('rotationmeasure',soltabName=soltabOut, 
+                            axesNames=['ant','time'], axesVals=[ants,times],
+                            vals = np.zeros((len(ants),len(times))),
+                            weights = np.ones((len(ants),len(times))))
+    else:
+        soltabout = solset.getSoltab(soltabOut)
+    soltabout.addHistory('Created by the FRJUMP operation from %s.'%soltab.name)
+
+
+    # Iterate through all antennas
+    
+    for vals,weights,coord,_ in soltab.getValuesIter(returnAxes='time',weight=True):
+        antname = coord['ant']
+        newvals = dejump(vals,wavels)
+        logging.info(f'Doing antenna {antname}')
+        soltabout.setSelection(ant=coord['ant'],time=coord['time'])          
+        soltabout.setValues(np.expand_dims(newvals,axis=1))
+    
+
+
+    return 0


### PR DESCRIPTION
Implemented a relatively straight-forward rotation measure dejumper (FRjump). This is implemented as a separate operation so it won't interfere with already established pipelines. Limited testing shows promising results, but I haven't tried it on relatively 'bad' data (maybe I need to build in some sort of warning if the noise on the fitted rotation measure is too large (~0.5*jump size). I calculate the jump in a similar way to TECjump.

I made this change before, but now I did a bit more testing - I also cleaned up the code a bit (no longer dependent on astropy, for example), and I include a warning when using the FRjump module (that it is still experimental)