### PR TITLE
Fixed bug with rotation table not being used in faraday fitting (also a typo is untypod)

### DIFF
--- a/losoto/operations/_faraday_timestep.py
+++ b/losoto/operations/_faraday_timestep.py
@@ -43,7 +43,7 @@ def _run_timestep(t,coord_rr,coord_ll,weights,vals,solType,coord,maxResidual):
             weight = 1
         else:       
             # high residual, flag
-            logging.warning('Bad solution for ant: '+coord['ant']+' (time: '+str(t)+', resdiaul: '+str(residual)+').')
+            logging.warning('Bad solution for ant: '+coord['ant']+' (time: '+str(t)+', residual: '+str(residual)+').')
             weight = 0
 
     return fitresultrm_wav[0],weight

--- a/losoto/operations/faraday.py
+++ b/losoto/operations/faraday.py
@@ -63,6 +63,8 @@ def run( soltab, soltabOut='rotationmeasure000', refAnt='', maxResidual=1.,ncpu=
             return 1
     elif solType == 'rotation':
         returnAxes = ['freq','time']
+        coord_rr = None
+        coord_ll = None
     else:
        logging.warning("Soltab type of "+soltab._v_name+" is of type "+solType+", should be phase or rotation. Ignoring.")
        return 1


### PR DESCRIPTION
Basically, in "faraday.py" there is an if statement that checks the soltabtype. If soltabtype==phase all went well, but if soltabtype==rotation it didn't define coord_RR/LL. coordRR/LL is not needed for rotation tables, so these are set to None (_faraday_timestep doesn't use it either if the table is a rotation table). This works with the h5 you gave me.