### PR TITLE
Fix issue 135

### DIFF
--- a/losoto/operations/interpolate.py
+++ b/losoto/operations/interpolate.py
@@ -146,16 +146,18 @@ def run( soltab, outsoltab, axisToRegrid, newdelta, delta='', maxFlaggedWidth=0,
             # If there are at least two unflagged points, interpolate with mask
             if log:
                 vals = np.log10(vals)
-            new_vals[selection] = np.interp(new_axisvals, orig_axisvals[unflagged],
+            print(selection)
+            print(type(selection))
+            new_vals[tuple(selection)] = np.interp(new_axisvals, orig_axisvals[unflagged],
                                             vals[unflagged], left=np.nan, right=np.nan)
 
             # For the weights, interpolate without the mask
-            new_weights[selection] = np.round(np.interp(new_axisvals, orig_axisvals, weights,
+            new_weights[tuple(selection)] = np.round(np.interp(new_axisvals, orig_axisvals, weights,
                                                         left=np.nan, right=np.nan))
 
         # Check for flagged gaps
         if maxFlaggedWidth > 1:
-            inv_weights = new_weights[selection].astype(bool).squeeze()
+            inv_weights = new_weights[tuple(selection)].astype(bool).squeeze()
             rank = len(inv_weights.shape)
             connectivity = nd.generate_binary_structure(rank, rank)
             mask_labels, count = nd.label(~inv_weights, connectivity)
@@ -165,7 +167,7 @@ def run( soltab, outsoltab, axisToRegrid, newdelta, delta='', maxFlaggedWidth=0,
                 if gapsize <= maxFlaggedWidth:
                     # Unflag narrow gaps
                     selection[axisind] = ind[0]
-                    new_weights[selection] = 1.0
+                    new_weights[tuple(selection)] = 1.0
 
     # Write new soltab
     solset = soltab.getSolset()

--- a/losoto/operations/interpolate.py
+++ b/losoto/operations/interpolate.py
@@ -146,8 +146,6 @@ def run( soltab, outsoltab, axisToRegrid, newdelta, delta='', maxFlaggedWidth=0,
             # If there are at least two unflagged points, interpolate with mask
             if log:
                 vals = np.log10(vals)
-            print(selection)
-            print(type(selection))
             new_vals[tuple(selection)] = np.interp(new_axisvals, orig_axisvals[unflagged],
                                             vals[unflagged], left=np.nan, right=np.nan)
 


### PR DESCRIPTION
This should fix #135. I managed to dig up a NumPy warning that slices should be tuples in newer versions from an older run:
```python
FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
```
Now it crashes instead of just warning. This fixes it for the interpolate option (as far as I have used it in LINC with an HBA calibrator scan) by casting the slice to a tuple. A small test ran seems to have run fine and I'm now running a full calibrator scan through to confirm.

**[Edit]**
Found the relevant release note: https://numpy.org/devdocs/release/1.23.0-notes.html

> Multidimensional indexing with non-tuple values is not allowed. Previously, code such as arr[ind] where ind = [[0, 1], [0, 1]] produced a FutureWarning and was interpreted as a multidimensional index (i.e., arr[tuple(ind)]). Now this example is treated like an array index over a single dimension (arr[array(ind)]). Multidimensional indexing with anything but a tuple was deprecated in NumPy 1.15.