### PR TITLE
Add context support for h5parm class

### DIFF
--- a/losoto/h5parm.py
+++ b/losoto/h5parm.py
@@ -96,7 +96,6 @@ class h5parm( object ):
 
         if os.path.isfile(self.fileName):
             if not tables.is_hdf5_file(self.fileName):
-                logging.critical('Not a HDF5 file: '+self.fileName+'.')
                 raise Exception('Not a HDF5 file: '+self.fileName+'.')
             if self._readonly:
                 logging.debug('Reading from '+self.fileName+'.')

--- a/losoto/h5parm.py
+++ b/losoto/h5parm.py
@@ -61,6 +61,13 @@ class h5parm( object ):
         compression level from 0 to 9 when creating the file, by default 5.
     complib : str, optional
         library for compression: lzo, zlib, bzip2, by default zlib.
+
+    Notes
+    -----
+    An `h5parm` object may be used in a ``with`` context. However, be aware
+    that the underlying HDF5 file object will be closed as soon as you exit
+    the context. You either need to call `h5parm.open()`, or create a new
+    context using the current `h5parm` object to re-open the HDF5 file object.
     """
 
     def __init__(self, h5parmFile, readonly=True, complevel=0, complib='zlib'):

--- a/losoto/h5parm.py
+++ b/losoto/h5parm.py
@@ -66,8 +66,10 @@ class h5parm( object ):
     -----
     An `h5parm` object may be used in a ``with`` context. However, be aware
     that the underlying HDF5 file object will be closed as soon as you exit
-    the context. You either need to call `h5parm.open()`, or create a new
-    context using the current `h5parm` object to re-open the HDF5 file object.
+    the context. To re-open the HDF5 file object, you need to create a new
+    ``with`` context using the current `h5parm` object.
+    Calling `h5parm.open()` explicitly is *not* recommended, because it is
+    not exception-safe.
     """
 
     def __init__(self, h5parmFile, readonly=True, complevel=0, complib='zlib'):
@@ -82,31 +84,6 @@ class h5parm( object ):
         self._complib = complib
 
         self.open()
-
-
-    def __enter__(self):
-        """
-        Called when entering a context.
-        """
-        self.open()
-        return self
-
-
-    def __exit__(self, *exc):
-        """
-        Called when exiting a context.
-        """
-        self.close()
-
-
-    def __str__(self):
-        """
-        Returns
-        -------
-        string
-            Info about H5parm contents.
-        """
-        return self.printInfo()
 
 
     def open(self):
@@ -153,6 +130,31 @@ class h5parm( object ):
         """
         logging.debug('Closing table.')
         self.H.close()
+
+
+    def __enter__(self):
+        """
+        Called when entering a context.
+        """
+        self.open()
+        return self
+
+
+    def __exit__(self, *exc):
+        """
+        Called when exiting a context.
+        """
+        self.close()
+
+
+    def __str__(self):
+        """
+        Returns
+        -------
+        string
+            Info about H5parm contents.
+        """
+        return self.printInfo()
 
 
     def makeSolset(self, solsetName=None, addTables=True):


### PR DESCRIPTION
An `h5parm` object can now also be used in a `with` context. To retain backward compatibility, the underlying HDF5 file object is still opened in the `__init__()` method, but is now closed in the `__exit__()` method, which is implicitly called when leaving the `with` context.

Existing code will continue to function as it used to. You still need to call `close()` explicitly to close the HDF5 file object. New code should preferably use the `h5parm` object only inside a `with` context, thus ensuring that the HDF5 file object will always be closed, even when an exception is raised and not caught.