### PR TITLE
Add .readthedocs.yaml file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# # Optionally declare the Python requirements required to build your docs
+# python:
+#   install:
+#     - requirements: docs/requirements.txt
+#     # Rapthor itself needs to be installed to generate the documentation.
+#     - method: pip
+#       path: .


### PR DESCRIPTION
Added a `.readthedocs.yaml` file, because the Read the Docs build system will start requiring a configuration file v2 (.readthedocs.yaml) starting on September 25, 2023.