### PR TITLE
Remove use of float16 dtypes

### DIFF
--- a/bin/H5parm_collector.py
+++ b/bin/H5parm_collector.py
@@ -121,7 +121,7 @@ for insoltab in insoltabs:
     logging.debug("Shape:"+str(allShape))
     allVals = np.empty( shape=allShape )
     allVals[:] = np.nan
-    allWeights = np.zeros( shape=allShape )#, dtype=np.float16 )
+    allWeights = np.zeros( shape=allShape )#, dtype=float )
 
     # fill arrays
     logging.info("Filling new table...")

--- a/losoto/_importer.py
+++ b/losoto/_importer.py
@@ -290,7 +290,7 @@ def create_h5parm(instrumentdbFiles, antennaFile, fieldFile, skydbFile,
         shape = [i for i in (len(pols), len(dirs), len(ants), len(freqs), len(times)) if i != 0]
         vals = np.empty(shape)
         vals[:] = np.nan
-        weights = np.zeros(shape, dtype=np.float16)
+        weights = np.zeros(shape, dtype=float)
 
         logging.info('Filling table.')
 

--- a/losoto/h5parm.py
+++ b/losoto/h5parm.py
@@ -545,13 +545,13 @@ class Solset( object ):
 
         # create the val/weight Carrays
         #val = self.obj._v_file.create_carray('/'+self.name+'/'+soltabName, 'val', obj=vals.astype(np.float64), chunkshape=None, atom=tables.Float64Atom())
-        #weight = self.obj._v_file.create_carray('/'+self.name+'/'+soltabName, 'weight', obj=weights.astype(np.float16), chunkshape=None, atom=tables.Float16Atom())
+        #weight = self.obj._v_file.create_carray('/'+self.name+'/'+soltabName, 'weight', obj=weights.astype(float), chunkshape=None, atom=tables.FloatAtom())
         # array do not have compression but are much faster
         val = self.obj._v_file.create_array('/'+self.name+'/'+soltabName, 'val', obj=vals.astype(np.float64), atom=tables.Float64Atom())
         assert weightDtype in ['f16','f32', 'f64'], "Allowed weight dtypes are 'f16','f32', 'f64'"
         if weightDtype == 'f16':
-            np_d = np.float16
-            pt_d = tables.Float16Atom()
+            np_d = float
+            pt_d = tables.FloatAtom()
         elif weightDtype == 'f32':
             np_d = np.float32
             pt_d = tables.Float32Atom()

--- a/losoto/operations/clocktec.py
+++ b/losoto/operations/clocktec.py
@@ -78,7 +78,7 @@ def run( soltab, tecsoltabOut='tec000', clocksoltabOut='clock000', offsetsoltabO
     solset = soltab.getSolset()
     station_dict = solset.getAnt()
     stations = soltab.getAxisValues('ant')
-    station_positions = np.zeros((len(stations), 3), dtype=np.float16)
+    station_positions = np.zeros((len(stations), 3), dtype=float)
     for i, station_name in enumerate(stations):
         station_positions[i, 0] = station_dict[station_name][0]
         station_positions[i, 1] = station_dict[station_name][1]
@@ -125,7 +125,7 @@ def run( soltab, tecsoltabOut='tec000', clocksoltabOut='clock000', offsetsoltabO
         weights=tec>-5
         tec[np.logical_not(weights)]=0
         clock[np.logical_not(weights)]=0
-        weights=np.float16(weights)
+        weights=weights.astype(float)
 
         if combinePol or not 'pol' in soltab.getAxesNames():
             tf_st = solset.makeSoltab('tec', soltabName = tecsoltabOut,
@@ -141,7 +141,7 @@ def run( soltab, tecsoltabOut='tec000', clocksoltabOut='clock000', offsetsoltabO
             tf_st = solset.makeSoltab('phase', soltabName = offsetsoltabOut,
                              axesNames=['ant'], axesVals=[stations],
                              vals=offset[:,0],
-                             weights=np.ones_like(offset[:,0],dtype=np.float16))
+                             weights=np.ones_like(offset[:,0],dtype=float))
             tf_st.addHistory('CREATE (by CLOCKTECFIT operation)')
             if fit3rdorder:
                 tf_st = solset.makeSoltab('tec3rd', soltabName = tec3rdsoltabOut,
@@ -162,7 +162,7 @@ def run( soltab, tecsoltabOut='tec000', clocksoltabOut='clock000', offsetsoltabO
             tf_st = solset.makeSoltab('phase', soltabName = offsetsoltabOut,
                              axesNames=['ant','pol'], axesVals=[stations, ['XX','YY']],
                              vals=offset,
-                             weights=np.ones_like(offset,dtype=np.float16))
+                             weights=np.ones_like(offset,dtype=float))
             tf_st.addHistory('CREATE (by CLOCKTECFIT operation)')
             if fit3rdorder:
                 tf_st = solset.makeSoltab('tec3rd', soltabName = tec3rdsoltabOut,

--- a/losoto/operations/frjump.py
+++ b/losoto/operations/frjump.py
@@ -26,9 +26,9 @@ def getPhaseWrapBase(wavels):
     """
     wavels = np.array(wavels)
     nF = wavels.shape[0]
-    A = np.zeros((nF, 1), dtype=np.float16)
+    A = np.zeros((nF, 1), dtype=float)
     A[:, 0] = 2*wavels**2
-    steps = np.dot(np.dot(np.linalg.inv(np.dot(A.T, A)), A.T), 2 * np.pi * np.ones((nF, ), dtype=np.float16))
+    steps = np.dot(np.dot(np.linalg.inv(np.dot(A.T, A)), A.T), 2 * np.pi * np.ones((nF, ), dtype=float))
     return steps
 
 def getPhaseWrapBase_TEC(freqs):
@@ -38,10 +38,10 @@ def getPhaseWrapBase_TEC(freqs):
     """
     freqs = np.array(freqs)
     nF = freqs.shape[0]
-    A = np.zeros((nF, 2), dtype=np.float16)
+    A = np.zeros((nF, 2), dtype=float)
     A[:, 1] = freqs * 2 * np.pi * 1e-9
     A[:, 0] = -8.44797245e9 / freqs
-    steps = np.dot(np.dot(np.linalg.inv(np.dot(A.T, A)), A.T), 4 * np.pi * np.ones((nF, ), dtype=np.float16))
+    steps = np.dot(np.dot(np.linalg.inv(np.dot(A.T, A)), A.T), 4 * np.pi * np.ones((nF, ), dtype=float))
     return steps[0]
 
 def dejump(vals,wavels,dotec=False):

--- a/losoto/operations/prefactor_XYoffset.py
+++ b/losoto/operations/prefactor_XYoffset.py
@@ -116,7 +116,7 @@ def run( soltab, chanWidth ):
     new_soltab = solset.makeSoltab(soltype='phase', soltabName='XYoffset',
                              axesNames=['freq', 'ant', 'pol'], axesVals=[freqs_new, soltab.ant, ['XX','YY']],
                              vals=global_stat_offsets_smoothed_interp,
-                             weights=np.ones_like(global_stat_offsets_smoothed_interp, dtype=np.float16))
+                             weights=np.ones_like(global_stat_offsets_smoothed_interp, dtype=float))
     new_soltab.addHistory('CREATE (by PREFACTOR_XYOFFSET operation)')
 
     return 0

--- a/losoto/operations/tecjump.py
+++ b/losoto/operations/tecjump.py
@@ -272,10 +272,10 @@ def run( soltab, refAnt='', soltabError='', ncpu=0 ):
         """
         freqs = np.array(freqs)
         nF = freqs.shape[0]
-        A = np.zeros((nF, 2), dtype=np.float16)
+        A = np.zeros((nF, 2), dtype=float)
         A[:, 1] = freqs * 2 * np.pi * 1e-9
         A[:, 0] = -8.44797245e9 / freqs
-        steps = np.dot(np.dot(np.linalg.inv(np.dot(A.T, A)), A.T), 2 * np.pi * np.ones((nF, ), dtype=np.float16))
+        steps = np.dot(np.dot(np.linalg.inv(np.dot(A.T, A)), A.T), 2 * np.pi * np.ones((nF, ), dtype=float))
         return steps
 
     if soltab.getType() != 'tec':

--- a/tools/swap_freq_time_axes.py
+++ b/tools/swap_freq_time_axes.py
@@ -53,7 +53,7 @@ def soltab_swap_freq_time(soltab):
     soltab.obj.weight._f_remove()
     # Create new val here
     soltab.obj._v_file.create_array(soltab.obj._v_pathname, 'val', obj=vals, atom=tables.Float64Atom())
-    soltab.obj._v_file.create_array(soltab.obj._v_pathname, 'weight', obj=weights, atom=tables.Float16Atom())
+    soltab.obj._v_file.create_array(soltab.obj._v_pathname, 'weight', obj=weights, atom=tables.FloatAtom())
     # Restore the original attributes
     for attrname in attrsdict:
         soltab.obj.val._f_setattr(attrname, attrsdict[attrname])


### PR DESCRIPTION
The use of float16 causes issues with, for example, NumPy's linalg routines. This PR removes instances where float16 is used and repaces them with float.

Fixes #142.