### PR TITLE
Remove Unused Dependency: Numexpr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     tests_require=['pytest'],
-    install_requires=['numpy>=1.9', 'cython', 'numexpr>=2.0', 'tables>=3.4', 'configparser',
+    install_requires=['numpy>=1.9', 'cython', 'tables>=3.4', 'configparser',
                       'scipy', 'matplotlib', 'python-casacore>=3.0'],
     scripts=['bin/losoto', 'bin/H5parm_split.py',
              'bin/H5parm2parmdb.py', 'bin/parmdb2H5parm.py', 'bin/killMS2H5parm.py',

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -26,7 +26,7 @@ apt-get install -y casacore libcasacore-dev
 apt-get install -y ipython python-matplotlib python-matplotlib-data python-pip \
 python-pyfits python-numpy python-scipy python-virtualenv python-sphinx \
 python-pygments python-jinja2 python-nose python-tornado cython python-zmq \
-python-pywcs python-astropy python-numexpr python-tables python-pandas \
+python-pywcs python-astropy python-tables python-pandas \
 ipython-notebook ipython-qtconsole
 
 
@@ -49,7 +49,6 @@ ipython-notebook ipython-qtconsole
 # pip install --upgrade matplotlib
 # pip install --upgrade astropy
 # pip install --upgrade pywcs
-# pip install --upgrade numexpr
 # pip install --upgrade tables
 # pip install --upgrade pandas
 # pip install --upgrade ipython


### PR DESCRIPTION
## Summary

Hello @revoltek,

I hope you're doing well! I've just opened this pull request that proposes the removal of the unused `numexpr` dependency from the `setup.py` configuration file. It's part of an ongoing research endeavor focusing on the identification and elimination of code bloat within software projects. Your insights on this would be really valuable.

## Rationale

The `numexpr` library was introduced  in f63a515. However, an examination of the current codebase revealed that it is not used within the project. Removing this unused dependency can reduce the overall footprint of the application, mitigate potential security risks, and simplify the dependency management process.

## Changes

- Removed the `numexpr`  dependency from the `setup.py` file.
- Updated `vagrant/bootstrap.sh` to reflect on the changes

## Impact

- Reduced package size: Eliminating this unused dependency will decrease the overall size of the installed packages.

- Simplified dependency tree: A leaner list of dependencies aids in more straightforward project maintenance and faster installations.

