### PR TITLE
Replace rcond with rtol in pinv() call

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -21,6 +21,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
       - name: Install
-        run: python setup.py install
+        run: pip install .
       - name: Test
-        run: python setup.py test
+        run: pytest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,4 +23,5 @@ jobs:
       - name: Install
         run: pip install .
       - name: Test
-        run: pytest -sv tools/losoto_test.py
+        # We cannot yet use `pytest`; requires different test file names
+        run: python tools/losoto_test.py

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Install
         run: pip install .
       - name: Test
-        run: pytest
+        run: pytest -sv tools/losoto_test.py

--- a/losoto/operations/directionscreen.py
+++ b/losoto/operations/directionscreen.py
@@ -248,9 +248,9 @@ def _fit_phase_screen(station_names, source_names, pp, airmass, rr, weights, tim
             D = np.transpose(D, (1, 0, 2)) - D
             D2 = np.sum(D**2, axis=2)
             C = -(D2 / r_0**2)**(beta / 2.0) / 2.0
-            pinvC = pinv(C, rcond=1e-3)
+            pinvC = pinv(C, rtol=1e-3)
             U, S, V = svd(C)
-            invU = pinv(np.dot(np.transpose(U[:, :order]), np.dot(weights[:, :, k], U[:, :order])), rcond=1e-3)
+            invU = pinv(np.dot(np.transpose(U[:, :order]), np.dot(weights[:, :, k], U[:, :order])), rtol=1e-3)
 
             # Calculate real screen
             rr1 = np.dot(np.transpose(U[:, :order]), np.dot(weights[:, :, k], rr_real[:, k]))
@@ -337,9 +337,9 @@ def _fit_tec_screen(station_names, source_names, pp, airmass, rr, weights, times
         D = np.transpose(D, (1, 0, 2)) - D
         D2 = np.sum(D**2, axis=2)
         C = -(D2 / r_0**2)**(beta / 2.0) / 2.0
-        pinvC = pinv(C, rcond=1e-3)
+        pinvC = pinv(C, rtol=1e-3)
         U, S, V = svd(C)
-        invU = pinv(np.dot(np.transpose(U[:, :order]), np.dot(weights[:, :, k], U[:, :order])), rcond=1e-3)
+        invU = pinv(np.dot(np.transpose(U[:, :order]), np.dot(weights[:, :, k], U[:, :order])), rtol=1e-3)
 
         # Calculate screen
         rr1 = np.dot(np.transpose(U[:, :order]), np.dot(weights[:, :, k], rr[:, k]))

--- a/losoto/operations/stationscreen.py
+++ b/losoto/operations/stationscreen.py
@@ -375,7 +375,7 @@ def _calculate_svd(pp, r_0, beta, N_piercepoints):
     D = np.transpose(D, (1, 0, 2)) - D
     D2 = np.sum(D**2, axis=2)
     C = -(D2 / r_0**2)**(beta / 2.0) / 2.0
-    pinvC = pinv(C, rcond=1e-3)
+    pinvC = pinv(C, rtol=1e-3)
     U, S, V = svd(C)
 
     return C, pinvC, U
@@ -439,7 +439,7 @@ def _fit_screen(source_names, full_matrices, pp, rr, weights, order, r_0, beta,
     else:
         # Recalculate for unflagged directions
         C, pinvC, U = _calculate_svd(pp, r_0, beta, N_piercepoints)
-    invU = pinv(np.dot(np.transpose(U[:, :order]), np.dot(w, U)[:, :order]), rcond=1e-3)
+    invU = pinv(np.dot(np.transpose(U[:, :order]), np.dot(w, U)[:, :order]), rtol=1e-3)
 
     # Fit screen to unflagged directions
     if screen_type == 'phase':

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     tests_require=['pytest'],
-    install_requires=['numpy>=1.9', 'cython', 'tables>=3.4', 'configparser',
+    install_requires=['numpy>=1.9,<2.0', 'cython', 'tables>=3.4', 'configparser',
                       'scipy', 'matplotlib', 'python-casacore>=3.0'],
     scripts=['bin/losoto', 'bin/H5parm_split.py',
              'bin/H5parm2parmdb.py', 'bin/parmdb2H5parm.py', 'bin/killMS2H5parm.py',


### PR DESCRIPTION
The `pinv()` function deprecated the use of `rcond` in favour of `rtol`, and SciPy 1.14.0 removed the keyword option `rcond` completely from `pinv()`. Replaced all occurrences of `rcond` in calls to `pinv()` with `rtol`.