### PR TITLE
Fix potential multiprocessing deadlock

### DIFF
--- a/losoto/lib_operations.py
+++ b/losoto/lib_operations.py
@@ -95,6 +95,14 @@ class multiprocManager(object):
         for t in self._threads:
             self.inQueue.put(None)
 
+        # Wait for all threads to finish
+        for t in self._threads:
+            t.join()
+
+        # Check if any thread exited with an error
+        if any(t.exitcode for t in self._threads):
+            raise RuntimeError("One or more worker threads exited with an error.")
+
         # wait for all jobs to finish
         self.inQueue.join()
         self.inQueue.close()


### PR DESCRIPTION
The module `lib_operations.py` contains a class `multiprocManager` that can be used to speed up calculations by spawning a bunch of sub-processes that each execute a given function. It uses input queues and output queues for communication. The potential deadlock is in the [`wait`](https://github.com/revoltek/losoto/blob/bbcfc5c26dc8c940a8fea9a45843277f188b6e63/losoto/lib_operations.py#L90)  function. If one of the worker processes dies (e.g. when an exception is raised in the function that's called), then trying to [join the input queue](https://github.com/revoltek/losoto/blob/bbcfc5c26dc8c940a8fea9a45843277f188b6e63/losoto/lib_operations.py#L99) will lead to a dead-lock. The rather brute-force solution is to check the return status of each of the worker processes before trying to join the input queue, and if any of them returned a non-zero exit status raise an exception.