### PR TITLE
Revert "Fix potential multiprocessing deadlock (#173)"

### DIFF
--- a/losoto/lib_operations.py
+++ b/losoto/lib_operations.py
@@ -95,14 +95,6 @@ class multiprocManager(object):
         for t in self._threads:
             self.inQueue.put(None)
 
-        # Wait for all threads to finish
-        for t in self._threads:
-            t.join()
-
-        # Check if any thread exited with an error
-        if any(t.exitcode for t in self._threads):
-            raise RuntimeError("One or more worker threads exited with an error.")
-
         # wait for all jobs to finish
         self.inQueue.join()
         self.inQueue.close()


### PR DESCRIPTION
This reverts commit 8c597063b4e03db1d0c45cc0d55942e3738f08f5.

The "solution" to fix the potential deadlock (#173) actually introduced a real deadlock in some day-to-day use cases. This MR reverts that change. 

Meanwhile, I am working on a new MR that hopefully properly fixes the potential deadlock. For now, this at least solves real deadlocks that people may encounter.