### PR TITLE
Use new lofar-parameterset package

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ authors = [
 maintainers = [
     { name = "Marcel Loose", email = "loose@astron.nl" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
+    "lofar-parameterset>=1.1",
     "matplotlib",
-    "numpy<2; python_version=='3.9'",
     "numpy",
     "progressbar",
     "python-casacore>=3.0",
@@ -64,7 +64,7 @@ write_to = "losoto/_version.py"
 
 [tool.tox]
 requires = ["tox>4"]
-envlist = ["py3{9,10,11,12,13}"]
+envlist = ["py3{10,11,12,13}"]
 
 [tool.tox.env_run_base]
 deps = [

--- a/tools/parmdb_collector.py
+++ b/tools/parmdb_collector.py
@@ -14,14 +14,14 @@ Bas van der Tol (vdtol@strw.leidenuniv.nl)"
 
 import sys, os, re
 import logging
-import lofar.parameterset
+from lofar_parameterset.parameterset import parameterset
 import losoto._version
 import losoto._logging
 
 def splitgds(gdsFile, wd='', id='part'):
     """Split gds file in multiple files
     """
-    ps = lofar.parameterset.parameterset(gdsFile)
+    ps = parameterset.fromFile(gdsFile)
     clusterdesc = ps.getString('ClusterDesc')
     starttime = ps.getString('StartTime')
     endtime = ps.getString('EndTime')
@@ -110,7 +110,7 @@ if __name__=='__main__':
     # Collect all the instrument tables
     instrumentdbFiles = []
     for instrumentdbGdsFile in instrumentdbGdsFiles:
-        instrumentdbParset = lofar.parameterset.parameterset(instrumentdbGdsFile)
+        instrumentdbParset = parameterset.fromFile(instrumentdbGdsFile)
         instrumentdbRemoteFile = instrumentdbParset.getString('Part0.FileName')
         instrumentdbHostname = instrumentdbParset.getString('Part0.FileSys').split(':')[0]
         instrumentdbFile = os.path.splitext(instrumentdbGdsFile)[0]
@@ -124,7 +124,7 @@ if __name__=='__main__':
             logging.info("Skipping "+instrumentdbFile)
         instrumentdbFiles.append(instrumentdbFile)
 
-    gdsParset = lofar.parameterset.parameterset(gdsFiles[0])
+    gdsParset = parameterset.fromFile(gdsFiles[0])
     # instrumentdbParset =
 
     hostname = gdsParset.getString('Part0.FileSys').split(':')[0]


### PR DESCRIPTION
### Changes

* Use the new pure-python `lofar-parameterset` package, instead of depending on the python bindings to the compiled LOFAR ParameterSet. 
* Dropped support for Python 3.9.