### PR TITLE
Fix for tox no longer doing brace expansion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ write_to = "losoto/_version.py"
 
 [tool.tox]
 requires = ["tox>4"]
-envlist = ["py3{10,11,12,13}"]
+env_list = ["py310", "py311", "py312", "py313"]
 
 [tool.tox.env_run_base]
 deps = [


### PR DESCRIPTION
Tox version 4.37 and higher no longer do brace expansion in expressions like:
```
envlist = ["py3{10,11,12,13}"]
```
We now need to write out this ourselves.

Thank you `tox` developers for making breaking API changes that are not even described in your Changelog. Great job!

It looks like a new feature was added to Tox 4.43, to fill the gap left behind when brace expansion was dropped. See https://github.com/tox-dev/tox/pull/3797 for details.