### PR TITLE
Bugfix h5parm_collector.py

### DIFF
--- a/bin/H5parm_collector.py
+++ b/bin/H5parm_collector.py
@@ -146,7 +146,7 @@ for insoltab in insoltabs:
 
     logging.info('Writing output...')
     solsetOutName = args.outsolset
-    soltabOutName = outsoltab or insoltab
+    soltabOutName = args.outsoltab or insoltab
 
     # create solset (and add all antennas and directions of other solsets)
     if solsetOutName in h5Out.getSolsetNames():


### PR DESCRIPTION
In an earlier merge request the variable `outsoltab` was not properly defined, since it is only given in the args parser.