### PR TITLE
fix_FJ_ref+reset

### DIFF
--- a/losoto/h5parm.py
+++ b/losoto/h5parm.py
@@ -1285,6 +1285,17 @@ class Soltab( object ):
                     refSelection[antAxis] = [self.getAxisValues('ant', ignoreSelection=True).tolist().index(refAnt)]
                     dataValsRef = self._applyAdvSelection(dataValsRef, refSelection)
 
+                    if 'pol' in self.getAxesNames() and not weight:
+                        ref_pol = False
+                        if 'XX' in self.getAxisValues('pol'): ref_pol = 'XX'
+                        elif 'RR' in self.getAxisValues('pol'): ref_pol = 'RR'
+                        logging.warning(f'Detected ref pol {ref_pol}')
+                        # reference to XX/RR only:
+                        if ref_pol:
+                            polAxis = self.getAxesNames().index('pol')
+                            refpolidx = list(self.getAxisValues('pol')).index(ref_pol) # most likely 0
+                            dataValsRef_polref = result = np.take(dataValsRef, [refpolidx], axis=polAxis)
+                            dataValsRef =  np.repeat(dataValsRef_polref, axis=polAxis, repeats=len(self.getAxisValues('pol')))
                     if weight:
                         dataVals[ np.repeat(dataValsRef, axis=antAxis, repeats=len(self.getAxisValues('ant'))) == 0. ] = 0.
                     else:
@@ -1470,7 +1481,7 @@ class Soltab( object ):
 
     def autoRefAnt(self):
         """
-        Get the least flagged antennas usign the 10 closest to the array centre
+        Get the least flagged antennas usign (up to) the 10 closest to the array centre
         """
         if self.cacheAutoRefAnt:
             return self.cacheAutoRefAnt
@@ -1488,11 +1499,12 @@ class Soltab( object ):
         # count of good datapoints
         nonflagged = np.count_nonzero(weights, axis=tuple([i for i in range(len(self.getAxesNames())) if i != antAxis]))
 
-        # get 10 closest antennas to the centroid
+        # get up to 10 closest antennas to the centroid
         usable_ants = self.getAxisValues('ant', ignoreSelection=True)
         dists_from_centroid = self.getSolset().getAntDist(ant_subset=usable_ants)
         dists =  np.array([dists_from_centroid[_] for _ in usable_ants])
-        idxCentralAnts = np.argpartition(dists, 10)[:10]
+        no_ants = min([10,len(dists)])
+        idxCentralAnts = np.argpartition(dists, no_ants)[:no_ants]
 
         autoRefAnt = usable_ants[idxCentralAnts][ np.argmax(nonflagged[idxCentralAnts]) ]
         logging.info('Auto-selected reference antenna: %s' % autoRefAnt)

--- a/losoto/operations/reset.py
+++ b/losoto/operations/reset.py
@@ -41,6 +41,27 @@ def run( soltab, dataVal=-999. ):
 
     if dataVal == -999.:
         if solType == 'amplitude':
+            axesNames = soltab.getAxesNames()
+            # special case full-Jones matrix
+            if 'pol' in axesNames:
+                polAxis = axesNames.index('pol')
+                if soltab.val.shape[polAxis] == 4: # assume four dimensions == full Jones
+                    logging.info("Detected full-Jones amplitudes")
+                    val, axesval = soltab.getValues()
+                    pols = axesval['pol']
+                    # iterate polarizations and set to one/zero depending on diagonal/off-diagonal
+                    for i, pol in enumerate(pols):
+                        # Build a slicing tuple
+                        slicer = [slice(None)] * val.ndim
+                        slicer[polAxis] = i # in the polarization dimension, pick the i-th entry
+                        resetval = 1. if pol in ['XX', 'YY', 'RR', 'LL'] else 0.
+                        # logging.info(f"Reset pol {pol} to {resetval}")
+                        val[tuple(slicer)] = resetval
+                    print(val.shape)
+                    soltab.setValues(val)
+                    soltab.addHistory('RESET')
+                    return 0
+
             dataVal = 1.
         else:
             dataVal = 0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "progressbar",
-    "python-casacore>=3.0",
+#    "python-casacore>=3.0",
     "scipy",
     "tables>=3.4"
 ]


### PR DESCRIPTION
Should fix a number of things that I encountered:
- 'reset' operation for Fulljones solutions correctly resets amplitudes to diag (#194)
- referencing of solutions with less than 10 stations (#183)
- referencing of solutions to antenna should happen to only one polarization, at least for the common case of forcing a certain refant or auto-referencing(#153)
- python casacore is removed as dependency (#189)