### PR TITLE
Bump versions of GitHub actions

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed for `setuptools-scm`
           fetch-depth: 0
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheel
         run: pipx run build --wheel
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           path: dist
 
@@ -42,11 +42,11 @@ jobs:
     # Ref: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release
     if: github.event_name == 'release' && github.event.action == 'released'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: dist  # put artifacts where next action expects them to be
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@release/v1.13
+      - uses: pypa/gh-action-pypi-publish@release/v1.14
         with:
           # For testing, use TestPyPI
           # repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,6 +31,8 @@ jobs:
       #     token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get Test Coverage
         uses: insightsengineering/coverage-action@v2
+        # Coverage should be the same for each python version, just pick one
+        if: matrix.python-version == '3.12'
         with:
           path: coverage.xml
           publish: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,8 +39,12 @@ jobs:
       - name: Get Test Coverage
         uses: insightsengineering/coverage-action@v3.0.2
         with:
-          # path: ./cobertura.xml
+          path: coverage.xml
           publish: true
+          diff: true
+          diff-branch: master
+          togglable-report: true
+          # exclude-detailed-coverage: true
 
       # - name: Run tests
       #   run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
       - name: Install
         run: pip install .[test]
       - name: Test
@@ -32,9 +33,9 @@ jobs:
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: coverage.xml
-          # badge: true
-          # format: markdown
-          # output: both
+          badge: true
+          format: markdown
+          output: both
 
       # - name: Run tests
       #   run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,10 +36,10 @@ jobs:
       #     badge: true
       #     format: markdown
       #     output: both
-      # - name: Get Test Coverage
-      #   uses: insightsengineering/coverage-action@v3
-      #   with:
-      #     path: ./cobertura.xml
+      - name: Get Test Coverage
+        uses: insightsengineering/coverage-action@v3.0.3
+        # with:
+        #   path: ./cobertura.xml
 
       # - name: Run tests
       #   run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,8 +38,9 @@ jobs:
       #     output: both
       - name: Get Test Coverage
         uses: insightsengineering/coverage-action@v3.0.2
-        # with:
-        #   path: ./cobertura.xml
+        with:
+          # path: ./cobertura.xml
+          publish: true
 
       # - name: Run tests
       #   run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
       #     format: markdown
       #     output: both
       - name: Get Test Coverage
-        uses: insightsengineering/coverage-action@v3.0.2
+        uses: insightsengineering/coverage-action@v3
         with:
           path: coverage.xml
           publish: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,13 +28,13 @@ jobs:
       #   with:
       #     coverageFile: coverage.xml
       #     token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Coverage summary
-        uses: irongut/code-coverage-summary@v1
+      - name: Code Coverage Summary Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: coverage.xml
-          badge: true
-          format: markdown
-          output: both
+          # badge: true
+          # format: markdown
+          # output: both
 
       # - name: Run tests
       #   run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,13 +29,17 @@ jobs:
       #   with:
       #     coverageFile: coverage.xml
       #     token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Code Coverage Summary Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+      # - name: Code Coverage Summary Report
+      #   uses: irongut/CodeCoverageSummary@v1.3.0
+      #   with:
+      #     filename: coverage.xml
+      #     badge: true
+      #     format: markdown
+      #     output: both
+      - name: Get Test Coverage
+        uses: insightsengineering/coverage-action@v3
         with:
-          filename: coverage.xml
-          badge: true
-          format: markdown
-          output: both
+          path: ./cobertura.xml
 
       # - name: Run tests
       #   run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,11 +23,19 @@ jobs:
       - name: Test
         run: tox
         continue-on-error: true
-      - name: Get Test Coverage
-        uses: orgoro/coverage@v3.2
+      # - name: Get Test Coverage
+      #   uses: orgoro/coverage@v3.2
+      #   with:
+      #     coverageFile: coverage.xml
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coverage summary
+        uses: irongut/code-coverage-summary@v1
         with:
-          coverageFile: coverage.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
+          filename: coverage.xml
+          badge: true
+          format: markdown
+          output: both
+
       # - name: Run tests
       #   run: |
       #     pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=losoto tests/ | tee pytest-coverage.txt

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
       #     format: markdown
       #     output: both
       - name: Get Test Coverage
-        uses: insightsengineering/coverage-action@v3.0.3
+        uses: insightsengineering/coverage-action@v2
         # with:
         #   path: ./cobertura.xml
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,10 +36,10 @@ jobs:
       #     badge: true
       #     format: markdown
       #     output: both
-      - name: Get Test Coverage
-        uses: insightsengineering/coverage-action@v3
-        with:
-          path: ./cobertura.xml
+      # - name: Get Test Coverage
+      #   uses: insightsengineering/coverage-action@v3
+      #   with:
+      #     path: ./cobertura.xml
 
       # - name: Run tests
       #   run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,13 +29,6 @@ jobs:
       #   with:
       #     coverageFile: coverage.xml
       #     token: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Code Coverage Summary Report
-      #   uses: irongut/CodeCoverageSummary@v1.3.0
-      #   with:
-      #     filename: coverage.xml
-      #     badge: true
-      #     format: markdown
-      #     output: both
       - name: Get Test Coverage
         uses: insightsengineering/coverage-action@v3
         with:
@@ -44,13 +37,3 @@ jobs:
           diff: true
           diff-branch: master
           togglable-report: true
-          # exclude-detailed-coverage: true
-
-      # - name: Run tests
-      #   run: |
-      #     pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=losoto tests/ | tee pytest-coverage.txt
-      # - name: Report test coverage
-      #   uses: MishaKav/pytest-coverage-comment@main
-      #   with:
-      #     pytest-coverage-path: ./pytest-coverage.txt
-      #     junitxml-path: ./pytest.xml

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,7 +30,7 @@ jobs:
       #     coverageFile: coverage.xml
       #     token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get Test Coverage
-        uses: insightsengineering/coverage-action@v3
+        uses: insightsengineering/coverage-action@v2
         with:
           path: coverage.xml
           publish: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
       #     format: markdown
       #     output: both
       - name: Get Test Coverage
-        uses: insightsengineering/coverage-action@v2
+        uses: insightsengineering/coverage-action@v3.0.2
         # with:
         #   path: ./cobertura.xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,5 @@ deps = [
     "pytest-cov",
 ]
 commands = [
-    # ["python", "{toxinidir}/tools/losoto_test.py"],
     ["python", "-m", "pytest", "--cov-report", "term", "--cov-report", "xml", "--cov-report", "html", "--cov=losoto", "tests/{posargs}"]
 ]


### PR DESCRIPTION
Several GitHub actions that we use in our CI/CD pipelines have recently upgraded to using Node 24. Since Node 20 will be deprecated in the near future, we needed to bump the version number of these actions. Also switched to another Code Coverage checker, because the one we were using appeared to be abandoned.