### PR TITLE
Partly revert the change with the referencing of diagonal solutions, …

### DIFF
--- a/losoto/h5parm.py
+++ b/losoto/h5parm.py
@@ -1200,7 +1200,7 @@ class Soltab( object ):
 
 
     @deprecated_alias(reference='refAnt') # Add alias for backwards compatibility
-    def getValues(self, retAxesVals=True, weight=False, refAnt=None, refDir=None):
+    def getValues(self, retAxesVals=True, weight=False, refAnt=None, refDir=None, preservePol=False):
         """
         Creates a simple matrix of values. Fetching a copy of all selected rows into memory.
 
@@ -1219,6 +1219,9 @@ class Soltab( object ):
         refDir : str, optional
             In case of phase or rotation solutions, reference to this Direction. By default no reference.
             If "center", reference to the central direction.
+        preservePol : bool, optional.
+            If True: When referencing a diagonal matrix, preserve the global X-Y offset by referencing only to X.
+            If False (default): reference both polarizations independently.
 
         Returns
         -------
@@ -1285,17 +1288,19 @@ class Soltab( object ):
                     refSelection[antAxis] = [self.getAxisValues('ant', ignoreSelection=True).tolist().index(refAnt)]
                     dataValsRef = self._applyAdvSelection(dataValsRef, refSelection)
 
+                    # for fullJones, or if preservePol is given, reference only to X/R polarization to preserve global X-Y delay
                     if 'pol' in self.getAxesNames() and not weight:
-                        ref_pol = False
-                        if 'XX' in self.getAxisValues('pol'): ref_pol = 'XX'
-                        elif 'RR' in self.getAxisValues('pol'): ref_pol = 'RR'
-                        logging.warning(f'Detected ref pol {ref_pol}')
-                        # reference to XX/RR only:
-                        if ref_pol:
-                            polAxis = self.getAxesNames().index('pol')
-                            refpolidx = list(self.getAxisValues('pol')).index(ref_pol) # most likely 0
-                            dataValsRef_polref = result = np.take(dataValsRef, [refpolidx], axis=polAxis)
-                            dataValsRef =  np.repeat(dataValsRef_polref, axis=polAxis, repeats=len(self.getAxisValues('pol')))
+                        if len(self.getAxisValues('pol')) == 4 or preservePol:
+                            ref_pol = False
+                            if 'XX' in self.getAxisValues('pol'): ref_pol = 'XX'
+                            elif 'RR' in self.getAxisValues('pol'): ref_pol = 'RR'
+                            logging.warning(f'Detected ref pol {ref_pol}')
+                            # reference to XX/RR only:
+                            if ref_pol:
+                                polAxis = self.getAxesNames().index('pol')
+                                refpolidx = list(self.getAxisValues('pol')).index(ref_pol) # most likely 0
+                                dataValsRef_polref = result = np.take(dataValsRef, [refpolidx], axis=polAxis)
+                                dataValsRef =  np.repeat(dataValsRef_polref, axis=polAxis, repeats=len(self.getAxisValues('pol')))
                     if weight:
                         dataVals[ np.repeat(dataValsRef, axis=antAxis, repeats=len(self.getAxisValues('ant'))) == 0. ] = 0.
                     else:

--- a/losoto/operations/reference.py
+++ b/losoto/operations/reference.py
@@ -9,12 +9,13 @@ logging.debug('Loading REFERENCE module.')
 def _run_parser(soltab, parser, step):
     refAnt = parser.getstr( step, 'refAnt', '' )
     refDir = parser.getstr( step, 'refDir', '' )
+    preservePol = parser.getbool( step, 'preservePol', False)
 
-    parser.checkSpelling( step, soltab, ['refAnt','refDir'])
-    return run(soltab, refAnt, refDir)
+    parser.checkSpelling( step, soltab, ['refAnt','refDir','preservePol'])
+    return run(soltab, refAnt, refDir, preservePol)
 
 
-def run( soltab, refAnt='', refDir=''):
+def run( soltab, refAnt='', refDir='', preservePol=False):
     """
     Reference to an antenna
 
@@ -24,6 +25,8 @@ def run( soltab, refAnt='', refDir=''):
         Reference antenna for phases. Empty string does not change phases. Default: ''.
     refDir : str, optional
         Reference direction for phases. Empty string does not change phases. Default: ''.
+    preservePol : bool, optional
+        For fullJones, or if preservePol is given, reference only to X/R polarization to preserve global X-Y delay
     """
 
     if not soltab.getType() in ['phase', 'scalarphase', 'rotation', 'tec', 'clock', 'tec3rd', 'rotationmeasure']:
@@ -40,16 +43,16 @@ def run( soltab, refAnt='', refDir=''):
             return 1
 
     if refDir != '' and refAnt != '':
-        vals = soltab.getValues(retAxesVals=False, refAnt=refAnt, refDir=refDir)
+        vals = soltab.getValues(retAxesVals=False, refAnt=refAnt, refDir=refDir, preservePol=preservePol)
 
     elif refDir != '':
-        vals = soltab.getValues(retAxesVals=False, refDir=refDir)
+        vals = soltab.getValues(retAxesVals=False, refDir=refDir, preservePol=preservePol)
 
     elif refAnt != '':
-        vals = soltab.getValues(retAxesVals=False, refAnt=refAnt)
+        vals = soltab.getValues(retAxesVals=False, refAnt=refAnt, preservePol=preservePol)
 
     soltab.setValues(vals)
 
-    if refAnt != '': soltab.addHistory('REFERENCED (to antenna: %s)' % (refAnt))
+    if refAnt != '': soltab.addHistory('REFERENCED (to antenna: %s, preservePol: %s)' % (refAnt, preservePol))
     if refDir != '': soltab.addHistory('REFERENCED (to direction: %s)' % (refDir))
     return 0


### PR DESCRIPTION
Partially revert my recent changes regarding the referencing of diagonal solutions: Per default, X and Y will now be again referenced independently, but there is the preservePol argument added. If specified, referencing happens only to X, such that the X-Y information is preserved.